### PR TITLE
Change build target to netstandard2.0

### DIFF
--- a/Wkhtmltopdf.NetCore/Wkhtmltopdf.NetCore.csproj
+++ b/Wkhtmltopdf.NetCore/Wkhtmltopdf.NetCore.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
-    <FileVersion>1.1.1.0</FileVersion>
-    <Version>1.1.1</Version>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyVersion>1.1.1.1</AssemblyVersion>
+    <FileVersion>1.1.1.1</FileVersion>
+    <Version>1.1.1-1</Version>
     <Description>This project implements the library wkhtmltopdf for net core, working in windows and linux and docker.
 
 For more information about how to use it, go to https://github.com/fpanaccia/Wkhtmltopdf.NetCore.Example</Description>
@@ -15,7 +15,6 @@ For more information about how to use it, go to https://github.com/fpanaccia/Wkh
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
-    <PackageReference Include="Microsoft.NETCore.App" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="RazorLight" Version="2.0.0-beta1" />
   </ItemGroup>


### PR DESCRIPTION
Hello fpanaccia,

I changed build target to netstandard2.0 so that both .net framework and .net core projects can use it. And I'd like to merge this change to your repo. So that we can use future nuget packages in multi-targeted projects.
Looking forward to your response. And thank you for this wonderful project.

And, to be clear, I've made following changes:

    1. change build target to netstandard2.0
    2. remove unnecessary dependencies
    3. change version to 1.1.1-1