### PR TITLE
Fix error when redirecting stream from wkhtmltopdf.exe

### DIFF
--- a/Wkhtmltopdf.NetCore/WkhtmlDriver.cs
+++ b/Wkhtmltopdf.NetCore/WkhtmlDriver.cs
@@ -56,6 +56,7 @@ namespace Wkhtmltopdf.NetCore
                 {
                     FileName = RotativaLocation,
                     Arguments = switches,
+                    UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     RedirectStandardInput = true,


### PR DESCRIPTION
Hello again,

Sorry to bother you again so soon. 😅 
I've made change to fix following error when using it on windows:

> System.InvalidOperationException: The Process object must have the UseShellExecute property set to false in order to redirect IO streams.
>    at Wkhtmltopdf.NetCore.WkhtmlDriver.Convert(String wkhtmlPath, String switches, String html)
>    at Wkhtmltopdf.NetCore.HtmlAsPdf.GetPDF(String html)
> ...

Just handle this merge request at your spare time. Thank you very much!