### PR TITLE
Add replacements

### DIFF
--- a/Wkhtmltopdf.NetCore/ConvertOptions.cs
+++ b/Wkhtmltopdf.NetCore/ConvertOptions.cs
@@ -28,6 +28,7 @@ namespace Wkhtmltopdf.NetCore
             this.HeaderSpacing = options.HeaderSpacing;
             this.FooterHtml = options.FooterHtml;
             this.FooterSpacing = options.FooterSpacing;
+            this.Replacements = options.Replacements;
         }
 
         /// <summary>
@@ -107,6 +108,13 @@ namespace Wkhtmltopdf.NetCore
         /// </summary>
         [OptionFlag("--footer-spacing")]
         public int? FooterSpacing { get; set; }
+
+        /// <summary>
+        /// Sets the variables to replace in the header and footer html
+        /// </summary>
+        /// <remarks>Replaces [name] with value in header and footer (repeatable).</remarks>
+        [OptionFlag("--replace")]
+        public Dictionary<string, string> Replacements { get; set; }
 
         protected string GetConvertOptions()
         {

--- a/Wkhtmltopdf.NetCore/ConvertOptions.cs
+++ b/Wkhtmltopdf.NetCore/ConvertOptions.cs
@@ -149,7 +149,7 @@ namespace Wkhtmltopdf.NetCore
                     var dictionary = (Dictionary<string, string>)value;
                     foreach (var d in dictionary)
                     {
-                        result.AppendFormat(" {0} {1} {2}", of.Name, d.Key, d.Value);
+                        result.AppendFormat(" {0} \"{1}\" \"{2}\"", of.Name, d.Key, d.Value);
                     }
                 }
                 else if (fi.PropertyType == typeof(bool))


### PR DESCRIPTION
This adds the `--replace` option argument as described in the [wkhtml docs](https://wkhtmltopdf.org/usage/wkhtmltopdf.txt)

The dictionary work was already done in `GetConvertBaseOptions`.