### PR TITLE
ExtendsOptionFlag

### DIFF
--- a/Wkhtmltopdf.NetCore/ConvertOptions.cs
+++ b/Wkhtmltopdf.NetCore/ConvertOptions.cs
@@ -13,24 +13,6 @@ namespace Wkhtmltopdf.NetCore
             this.PageMargins = new Margins();
         }
 
-        protected void SetOptions(ConvertOptions options)
-        {
-            this.PageMargins = new Margins();
-            this.PageSize = options.PageSize;
-            this.PageWidth = options.PageWidth;
-            this.PageHeight = options.PageHeight;
-            this.PageOrientation = options.PageOrientation;
-            this.PageMargins = options.PageMargins;
-            this.IsLowQuality = options.IsLowQuality;
-            this.Copies = options.Copies;
-            this.IsGrayScale = options.IsGrayScale;
-            this.HeaderHtml = options.HeaderHtml;
-            this.HeaderSpacing = options.HeaderSpacing;
-            this.FooterHtml = options.FooterHtml;
-            this.FooterSpacing = options.FooterSpacing;
-            this.Replacements = options.Replacements;
-        }
-
         /// <summary>
         /// Sets the page size.
         /// </summary>
@@ -116,7 +98,7 @@ namespace Wkhtmltopdf.NetCore
         [OptionFlag("--replace")]
         public Dictionary<string, string> Replacements { get; set; }
 
-        protected string GetConvertOptions()
+        public string GetConvertOptions()
         {
             var result = new StringBuilder();
 

--- a/Wkhtmltopdf.NetCore/Implementation/GeneratePdf.cs
+++ b/Wkhtmltopdf.NetCore/Implementation/GeneratePdf.cs
@@ -5,29 +5,31 @@ using System.Threading.Tasks;
 
 namespace Wkhtmltopdf.NetCore
 {
-    public class GeneratePdf : ConvertOptions, IGeneratePdf
+    public class GeneratePdf : IGeneratePdf
     {
+        protected ConvertOptions _convertOptions;
         readonly IRazorViewToStringRenderer _engine;
         public GeneratePdf(IRazorViewToStringRenderer engine)
         {
             _engine = engine;
+            _convertOptions = new ConvertOptions();
         }
 
         public void SetConvertOptions(ConvertOptions options)
         {
-            this.SetOptions(options);
+            this._convertOptions = options;
         }
 
         public byte[] GetPDF(string html)
         {
-            return WkhtmlDriver.Convert(WkhtmltopdfConfiguration.RotativaPath, this.GetConvertOptions(), html);
+            return WkhtmlDriver.Convert(WkhtmltopdfConfiguration.RotativaPath, this._convertOptions.GetConvertOptions(), html);
         }
 
         public async Task<byte[]> GetByteArray<T>(string View, T model)
         {
             try
             {
-                
+
                 var html = await _engine.RenderViewToStringAsync(View, model);
                 return GetPDF(html);
             }

--- a/Wkhtmltopdf.NetCore/Options/OptionFlag.cs
+++ b/Wkhtmltopdf.NetCore/Options/OptionFlag.cs
@@ -2,7 +2,7 @@
 
 namespace Wkhtmltopdf.NetCore.Options
 {
-    class OptionFlag : Attribute
+    public class OptionFlag : Attribute
     {
         public string Name { get; private set; }
 


### PR DESCRIPTION
HI,
I want to expand the argument of Wkhtmltopdf. 
This is my rewrite.
It can override from outside.

for example

```CSharp

public class PdfConvertOptions: ConvertOptions
{
    /// <summary>
    /// Change the dpi explicitly (this has noeffect on X11 based systems) (default 96)
    /// </summary>
    [OptionFlag("--dpi")]
    public int DPI { get; set; }
    
    /// <summary>
    /// Use print media-type instead of screen
    /// </summary>
    [OptionFlag("--print-media-type")]
    public bool PrintMediaType { get; set; }

    /// <summary>
    ///  Disable the intelligent shrinking strategy used by WebKit that makes the pixel/dpi ratio non-constant
    /// </summary>
    [OptionFlag("--disable-smart-shrinking")]
    public bool DisableSmartShrinking { get; set; }
}
```

Continue to use, I can enjoy new version of Wkhtmltopdf

```CSharp
_generatePdf.SetConvertOptions(getConvertOptions());
```