### PR TITLE
Added DPI parameter to ConverterOptions

### DIFF
--- a/Wkhtmltopdf.NetCore/Implementation/ConvertOptions.cs
+++ b/Wkhtmltopdf.NetCore/Implementation/ConvertOptions.cs
@@ -12,7 +12,15 @@ namespace Wkhtmltopdf.NetCore
         public ConvertOptions()
         {
             this.PageMargins = new Margins();
+            this.DPI = 96;
         }
+
+        /// <summary>
+        /// Change the dpi explicitly
+        /// </summary>
+        /// <remarks>Default value is 96</remarks>
+        [OptionFlag("-d")]
+        public int? DPI { get; set; }
 
         /// <summary>
         /// Sets the page size.


### PR DESCRIPTION
Added DPI parameter to ConverterOptions. It fixes invalid letter-spacing bug when set to 300. Default value is 96.