### PR TITLE
Adding a build/.props file to auto copy the required files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,7 @@ For more information about how to use it, go to https://github.com/fpanaccia/Wkh
 
 # But i don't want to see another repository
 
-You will need to put this files with this following structure, this need to be done because nuget cant copy those files, only puts a link with the full path and will only work on your computer.
-
-The structure will need to be on the folder of your project
-
-        .
-        ├── Example
-        |   ├── Example.csproj
-        |   └── Rotativa
-        |   |   ├── Linux
-        |   |   |   └── wkhtmltopdf
-        |   |   ├── Mac
-        |   |   |   └── wkhtmltopdf
-        |   |   └── Windows
-        |   |       └── wkhtmltopdf.exe
-        └── Example.sln
-
-Those files will need to be included in your project with the propierty "Copy Always", then add to your Startup.cs in ConfigureServices method, this line "services.AddWkhtmltopdf();", like this
+Add to your Startup.cs in ConfigureServices method, this line "services.AddWkhtmltopdf();", like this
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)

--- a/Wkhtmltopdf.NetCore/Wkhtmltopdf.NetCore.csproj
+++ b/Wkhtmltopdf.NetCore/Wkhtmltopdf.NetCore.csproj
@@ -26,6 +26,7 @@ For more information about how to use it, go to https://github.com/fpanaccia/Wkh
 
   <ItemGroup>
     <None Include="build\net5.0\*" Pack="true" PackagePath="build\netcoreapp3.0" />
+    <None Include="build\*.props" Pack="true" PackagePath="build" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Wkhtmltopdf.NetCore/build/Wkhtmltopdf.NetCore.props
+++ b/Wkhtmltopdf.NetCore/build/Wkhtmltopdf.NetCore.props
@@ -1,0 +1,14 @@
+<Project>
+  <Target Name="CopyFilesToBuild" BeforeTargets="Build">
+    <ItemGroup>     
+      <Files Include="$(MSBuildThisFileDirectory)../Rotativa/**/*.*"></Files>          
+    </ItemGroup>
+    <Copy SourceFiles="@(Files)" DestinationFolder="$(OutputPath)\Rotativa\%(RecursiveDir)" />
+  </Target>
+  <Target Name="CopyFilesToPublish" AfterTargets="AfterPublish">
+    <ItemGroup>
+      <Files Include="$(MSBuildThisFileDirectory)../Rotativa/**/*.*"></Files>
+    </ItemGroup>
+    <Copy SourceFiles="@(Files)" DestinationFolder="$(PublishDir)\Rotativa\%(RecursiveDir)"/>
+  </Target>
+</Project>


### PR DESCRIPTION
Hi, I've been using this package and I discovered a way to automatically copy the required files to the build/publish folder. I think it can make easier consumers to use the package.